### PR TITLE
Mudando de componentDidMount para useEffect

### DIFF
--- a/src/components/Comments/index.tsx
+++ b/src/components/Comments/index.tsx
@@ -1,26 +1,17 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { Component } from 'react';
+import { useEffect } from 'react';
 
-export default class Comments extends Component {
-  componentDidMount() {
+export default function Comments(): JSX.Element {
+  useEffect(() => {
     const script = document.createElement('script');
     const anchor = document.getElementById('inject-comments-for-uterances');
     script.setAttribute('src', 'https://utteranc.es/client.js');
     script.setAttribute('crossorigin', 'anonymous');
     script.setAttribute('async', 'true');
     script.setAttribute('repo', 'GBDev13/space-traveling');
-    script.setAttribute('issue-term', 'pathname');
+    script.setAttribute('issue-term', 'title');
     script.setAttribute('theme', 'dark-blue');
     anchor.appendChild(script);
-  }
+  }, []);
 
-  render() {
-    return (
-      <div
-        id="inject-comments-for-uterances"
-        style={{ marginBottom: '4rem' }}
-      />
-    );
-  }
+  return <div id="inject-comments-for-uterances" style={{ marginBottom: '4rem' }} />;
 }


### PR DESCRIPTION
Segundo a documentação do React, os métodos `componentDidMount`, `componentDidUpdate`, e `componentWillUnmount` são considerados legados e você deve evitá-los.

Prefira usar o `useEffect` no lugar.

Isso também vai eliminar os avisos e erros do VS Code.

Seus vídeos são muito bons, cara. Parabéns.